### PR TITLE
quark monster box performance fix

### DIFF
--- a/src/main/java/fermiummixins/config/QuarkConfig.java
+++ b/src/main/java/fermiummixins/config/QuarkConfig.java
@@ -170,4 +170,15 @@ public class QuarkConfig {
 			reason = "Requires mod to properly function"
 	)
 	public boolean usageTickerForcedVisible = false;
+
+	@Config.Comment("Increases performance of Monster Boxes looking for players nearby to activate")
+	@Config.Name("Monster Box Check Player Performance (Quark)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(lateMixin = "mixins.fermiummixins.late.quark.monsterboxperformance.json", defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.Quark_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean monsterBoxPerformance = false;
 }

--- a/src/main/java/fermiummixins/mixin/quark/TileMonsterBox_PerformanceMixin.java
+++ b/src/main/java/fermiummixins/mixin/quark/TileMonsterBox_PerformanceMixin.java
@@ -1,0 +1,40 @@
+package fermiummixins.mixin.quark;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
+import net.minecraft.tileentity.TileEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import vazkii.quark.world.tile.TileMonsterBox;
+
+@Mixin(TileMonsterBox.class)
+public abstract class TileMonsterBox_PerformanceMixin extends TileEntity {
+
+    //This mixin just replaces the expensive
+    // world.getEntitiesWithinAABB(EntityPlayer.class)
+    // with world.isAnyPlayerInRangeAt()
+
+    // method is called every tick per monster box so not good
+
+    // Most performant fix I could find was just skipping the whole if(!doBreak){} with the following two @ModifyVariable (one before, one after)
+
+    @ModifyVariable(
+            method = "update",
+            name = "doBreak",
+            at = @At(value = "LOAD", ordinal = 0)
+    )
+    private boolean fermiumMixins_quarkMonsterBox_update_loadBefore(boolean doBreak, @Share("actuallyBreak") LocalBooleanRef actuallyBreak){
+        actuallyBreak.set(doBreak || this.world.isAnyPlayerWithinRangeAt(this.getPos().getX(), this.getPos().getY(), this.getPos().getZ(), 2.5));
+        return true;
+    }
+
+    @ModifyVariable(
+            method = "update",
+            name = "doBreak",
+            at = @At(value = "LOAD", ordinal = 1)
+    )
+    private boolean fermiumMixins_quarkMonsterBox_update_loadAfter(boolean doBreak, @Share("actuallyBreak") LocalBooleanRef actuallyBreak){
+        return actuallyBreak.get();
+    }
+}

--- a/src/main/resources/mixins.fermiummixins.late.quark.monsterboxperformance.json
+++ b/src/main/resources/mixins.fermiummixins.late.quark.monsterboxperformance.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "quark.TileMonsterBox_PerformanceMixin"
+  ]
+}


### PR DESCRIPTION
monster boxes search through all loaded entities for players nearby, every tick. 
this mixin makes them just look for players directly.