### PR TITLE
fix new blockstateidentitymap startup crash

### DIFF
--- a/src/main/java/fermiummixins/wrapper/BlockStateIdentityPatchWrapper.java
+++ b/src/main/java/fermiummixins/wrapper/BlockStateIdentityPatchWrapper.java
@@ -42,17 +42,13 @@ public abstract class BlockStateIdentityPatchWrapper {
 			}
 			Integer prevVal = this.identityArray.set(fixKey, value);
 			
-			if(prevVal == null) {
+			if(prevVal == null || prevVal != value) {
 				while(this.objectList.size() <= value) {
 					this.objectList.add(null);
 				}
 				this.objectList.set(value, key);
 				
 				this.size++;
-			}
-			else if(prevVal != value) {
-				//This shouldn't ever happen, but handle for it anyways
-				this.objectList.set(value, key);
 			}
 		}
 		


### PR DESCRIPTION
i got no clue what im doing but this seems to fix it

_it_ being this on startup start (tripwire special case): 
<img width="1608" height="747" alt="grafik" src="https://github.com/user-attachments/assets/8edb9afc-3854-47ad-851a-f7b6923375ba" />
