### PR TITLE
DRAFT foamfix unload entities patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation fg.deobf("curse.maven:elenai-${elenai_version}")
     implementation fg.deobf("curse.maven:fancymenu-${fancymenu_version}")
     implementation fg.deobf("curse.maven:firstaid-${firstaid_version}")
+    implementation fg.deobf("curse.maven:foamfix-optimization-mod-${foamfix_version}")
     implementation fg.deobf("curse.maven:foodexpansion-${foodexpansion_version}")
     implementation fg.deobf("curse.maven:forgottenitems-${forgottenitems_version}")
     implementation fg.deobf("curse.maven:infernalmobs-${infernalmobs_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,6 +60,7 @@ dynamicsurroundingshud_version=309318:2820653
 elenai_version=373104:3575333
 fancymenu_version=367706:4655936
 firstaid_version=276837:4414252
+foamfix_version=278494:3973967
 foodexpansion_version=235328:2573308
 forgottenitems_version=262884:4167346
 infernalmobs_version=227875:2771611

--- a/src/main/java/fermiummixins/config/FoamFixConfig.java
+++ b/src/main/java/fermiummixins/config/FoamFixConfig.java
@@ -1,0 +1,31 @@
+package fermiummixins.config;
+
+import fermiumbooter.annotations.MixinConfig;
+import fermiummixins.FermiumMixins;
+import fermiummixins.util.ModLoadedUtil;
+import net.minecraft.block.Block;
+import net.minecraft.init.Blocks;
+import net.minecraft.util.ResourceLocation;
+import net.minecraftforge.common.config.Config;
+import net.minecraftforge.fml.common.registry.ForgeRegistries;
+import org.apache.logging.log4j.Level;
+
+import java.util.HashSet;
+
+@MixinConfig(name = FermiumMixins.MODID)
+public class FoamFixConfig {
+	
+	@Config.Comment("Patch \"fixWorldEntityCleanup\" of FoamFix rarely creating ConcurrentModificationException crashes due to being older than the forge code it fixes.")
+	@Config.Name("Patch World Entity Cleanup Fix (FoamFix)")
+	@Config.RequiresMcRestart
+	@MixinConfig.MixinToggle(
+			earlyMixin = "mixins.fermiummixins.early.foamfix.unloadentities.json",
+			lateMixin = "mixins.fermiummixins.late.foamfix.unloadentities.json",
+			defaultValue = false)
+	@MixinConfig.CompatHandling(
+			modid = ModLoadedUtil.FoamFix_MODID,
+			desired = true,
+			reason = "Requires mod to properly function"
+	)
+	public boolean patchUpdateEntitiesPatch = false;
+}

--- a/src/main/java/fermiummixins/handlers/ConfigHandler.java
+++ b/src/main/java/fermiummixins/handlers/ConfigHandler.java
@@ -91,6 +91,9 @@ public class ConfigHandler {
 	
 	@Config.Name("FirstAid Config")
 	public static final FirstAidConfig FIRSTAID_CONFIG = new FirstAidConfig();
+
+	@Config.Name("FoamFix Config")
+	public static final FoamFixConfig FOAMFIX_CONFIG = new FoamFixConfig();
 	
 	@Config.Name("FoodExpansion Config")
 	public static final FoodExpansionConfig FOODEXPANSION_CONFIG = new FoodExpansionConfig();

--- a/src/main/java/fermiummixins/mixin/foamfix/WorldRemovalInjectMixin.java
+++ b/src/main/java/fermiummixins/mixin/foamfix/WorldRemovalInjectMixin.java
@@ -1,0 +1,21 @@
+package fermiummixins.mixin.foamfix;
+
+import fermiummixins.mixin.foamfix.vanilla.WorldAccessor;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import pl.asie.foamfix.coremod.injections.WorldRemovalInject;
+
+@Mixin(WorldRemovalInject.class)
+public abstract class WorldRemovalInjectMixin {
+
+    @Inject(
+            method = "foamfix_removeUnloadedEntities",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/profiler/Profiler;endStartSection(Ljava/lang/String;)V")
+    )
+    public void foamfix_removeUnloadedEntities(CallbackInfo ci) {
+        //The patch by FoamFix was created before Forge added this line in World.updateEntities
+        ((WorldAccessor) this).setProcessingLoadedTiles(true); //FML Move above remove to prevent CMEs
+    }
+}

--- a/src/main/java/fermiummixins/mixin/foamfix/vanilla/WorldAccessor.java
+++ b/src/main/java/fermiummixins/mixin/foamfix/vanilla/WorldAccessor.java
@@ -1,0 +1,11 @@
+package fermiummixins.mixin.foamfix.vanilla;
+
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(World.class)
+public interface WorldAccessor {
+    @Accessor("processingLoadedTiles")
+    void setProcessingLoadedTiles(boolean newValue);
+}

--- a/src/main/java/fermiummixins/util/ModLoadedUtil.java
+++ b/src/main/java/fermiummixins/util/ModLoadedUtil.java
@@ -35,6 +35,7 @@ public abstract class ModLoadedUtil {
 	public static final String ElenaiDodge_MODID = "elenaidodge";
 	public static final String FancyMenu_MODID = "fancymenu";
 	public static final String FirstAid_MODID = "firstaid";
+	public static final String FoamFix_MODID = "foamfix";
 	public static final String FoodExpansion_MODID = "foodexpansion";
 	public static final String ForgottenItems_MODID = "forgottenitems";
 	public static final String InfernalMobs_MODID = "infernalmobs";

--- a/src/main/resources/mixins.fermiummixins.early.foamfix.unloadentities.json
+++ b/src/main/resources/mixins.fermiummixins.early.foamfix.unloadentities.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "foamfix.vanilla.WorldAccessor"
+  ]
+}

--- a/src/main/resources/mixins.fermiummixins.late.foamfix.unloadentities.json
+++ b/src/main/resources/mixins.fermiummixins.late.foamfix.unloadentities.json
@@ -1,0 +1,11 @@
+{
+  "required": true,
+  "package": "fermiummixins.mixin",
+  "refmap": "mixins.fermiummixins.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+    "foamfix.WorldRemovalInjectMixin"
+  ]
+}


### PR DESCRIPTION
created concurrentmodificationexceptions for me about 10 times per day on a server. it was missing one line that forge probably added after that foamfix patch was made (2017)